### PR TITLE
Fix failing tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/frontend.bats
+        run: ./tests/bats/bin/bats ./tests/phpunit.bats
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/
+        run: ./tests/bats/bin/bats ./tests/frontend.bats
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/
+        run: ./tests/bats/bin/bats ./tests/frontend-local-test.bats
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/dkan-init.bats
+        run: ./tests/bats/bin/bats ./tests/
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/
+        run: ./tests/bats/bin/bats ./tests/project-test-phpunit.bats
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -84,7 +84,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/project-test-phpunit.bats
+        run: ./tests/bats/bin/bats ./tests
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/frontend-local-test.bats
+        run: ./tests/bats/bin/bats ./tests/
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/phpunit.bats
+        run: ./tests/bats/bin/bats ./tests/
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,10 +39,9 @@ jobs:
     strategy:
       matrix:
         ddev_version: [stable, HEAD]
-      #        ddev_version: [stable, edge, HEAD, PR]
       fail-fast: false
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -85,7 +85,7 @@ jobs:
         if: github.event.inputs.debug_enabled == 'true'
 
       - name: tests
-        run: ./tests/bats/bin/bats ./tests/
+        run: ./tests/bats/bin/bats ./tests/dkan-init.bats
 
       # keepalive-workflow adds a dummy commit if there's no other action here, keeps
       # GitHub from turning off tests after 60 days

--- a/config.dkan.yaml
+++ b/config.dkan.yaml
@@ -18,27 +18,6 @@ use_dns_when_possible: true
 composer_version: "2"
 nodejs_version: "16"
 
-webimage_extra_packages:
-  - chromium
-  - chromium-driver
-  - g++
-  - libgtk2.0-0
-  - libgtk-3-0
-  - libgbm-dev
-  - libnotify-dev
-  - libgconf-2-4
-  - libnss3
-  - libxss1
-  - libasound2
-  - libxtst6
-  - make
-  - python2
-  - python3-pip
-  - unzip
-  - wget
-  - xauth
-  - xvfb
-
 web_environment:
   - COMPOSER_MEMORY_LIMIT=-1
   - PHP_MEM_LIMIT=256M

--- a/tests/dkan-init.bats
+++ b/tests/dkan-init.bats
@@ -11,6 +11,7 @@ setup() {
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
+  rm -rf *
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
   ddev restart >/dev/null
@@ -61,8 +62,8 @@ teardown() {
 
   touch composer.json
 
-  run ddev dkan-init --project-version 10.1.x-dev
-  assert_output --partial "Using project version: 10.1.x-dev"
+  run ddev dkan-init --project-version 10.0.x-dev
+  assert_output --partial "Using project version: 10.0.x-dev"
   assert_output --partial "Found composer.json"
   assert_failure
 

--- a/tests/dkan-init.bats
+++ b/tests/dkan-init.bats
@@ -5,12 +5,12 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export TESTDIR=~/tmp/test-addon-template
+  export TESTDIR=~/tmp/test-addon-init
   mkdir -p $TESTDIR
-  export PROJNAME=test-addon-template
+  export PROJNAME=test-addon-init
   export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   rm -rf *
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}

--- a/tests/frontend-local-test.bats
+++ b/tests/frontend-local-test.bats
@@ -5,7 +5,7 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-dkan-frontend
+  export PROJNAME=test-dkan-frontend-local
   export TESTDIR=~/tmp/$PROJNAME
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true

--- a/tests/frontend-local-test.bats
+++ b/tests/frontend-local-test.bats
@@ -7,11 +7,12 @@ setup() {
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
   export PROJNAME=test-dkan-frontend
   export TESTDIR=~/tmp/$PROJNAME
-  mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
+  rm -rf $TESTDIR
+  mkdir -p $TESTDIR
   cd "${TESTDIR}"
-  rm -rf *
+  pwd
 
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}

--- a/tests/frontend-local-test.bats
+++ b/tests/frontend-local-test.bats
@@ -5,18 +5,19 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-dkan-ddev-addon
+  export PROJNAME=test-dkan-frontend
   export TESTDIR=~/tmp/$PROJNAME
   mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
   cd "${TESTDIR}"
+  rm -rf *
 
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
+  ddev dkan-init --force
   mv .ddev/misc/docker-compose.cypress.yaml .ddev/docker-compose.cypress.yml
   ddev restart
-  ddev dkan-init --force
   ddev dkan-site-install
   ddev dkan-frontend-install
   ddev dkan-frontend-build

--- a/tests/frontend.bats
+++ b/tests/frontend.bats
@@ -5,8 +5,9 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-dkan-ddev-addon
+  export PROJNAME=test-dkan-frontend-local
   export TESTDIR=~/tmp/$PROJNAME
+  rm -rf $TESTDIR
   mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true

--- a/tests/frontend.bats
+++ b/tests/frontend.bats
@@ -5,19 +5,20 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-dkan-frontend-local
+  export PROJNAME=test-dkan-frontend
   export TESTDIR=~/tmp/$PROJNAME
-  rm -rf $TESTDIR
-  mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
+  rm -rf $TESTDIR
+  mkdir -p $TESTDIR
   cd "${TESTDIR}"
+  pwd
 
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
+  ddev dkan-init --force
   mv .ddev/misc/docker-compose.cypress.yaml .ddev/docker-compose.cypress.yml
   ddev restart
-  ddev dkan-init --force
   ddev dkan-site-install
 }
 

--- a/tests/phpunit.bats
+++ b/tests/phpunit.bats
@@ -5,16 +5,17 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-dkan-ddev-addon
+  export PROJNAME=test-dkan-phpunit
   export TESTDIR=~/tmp/$PROJNAME
-  mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
+  rm -rf $TESTDIR
+  mkdir -p $TESTDIR
   cd "${TESTDIR}"
+  pwd
+
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
-  ddev restart
-
   ddev dkan-init --force
   # TODO: Change this after https://www.drupal.org/project/moderated_content_bulk_publish/issues/3301389
   ddev composer require drupal/pathauto:^1.10

--- a/tests/project-test-phpunit.bats
+++ b/tests/project-test-phpunit.bats
@@ -41,12 +41,7 @@ teardown() {
   assert_output --partial "PHPUnit config not found"
   assert_failure
 
-  # Add config.
-  mkdir -p docroot/modules/custom
-  cp .ddev/misc/phpunit.xml docroot/modules/custom
-
   # Can perform test run, for a group that doesn't exist.
-  ddev dkan-init --force
   mkdir -p docroot/modules/custom
   cp .ddev/misc/phpunit.xml docroot/modules/custom
   run ddev project-test-phpunit --group this-group-should-not-exist

--- a/tests/project-test-phpunit.bats
+++ b/tests/project-test-phpunit.bats
@@ -4,8 +4,10 @@ setup() {
   load 'test_helper/bats-support/load'
   load 'test_helper/bats-assert/load'
 
-  export SUT_DIR=$(pwd)
-  export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
+  SUT_DIR=$(pwd)
+  export SUT_DIR
+  DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
+  export DIR
   export PROJNAME=test-dkan-phpunit
   export TESTDIR=~/tmp/$PROJNAME
   export DDEV_NON_INTERACTIVE=true
@@ -13,7 +15,6 @@ setup() {
   rm -rf $TESTDIR
   mkdir -p $TESTDIR
   cd "${TESTDIR}"
-  pwd
 
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
@@ -40,12 +41,9 @@ teardown() {
   assert_output --partial "PHPUnit config not found"
   assert_failure
 
-  # Add config, but no executable.
+  # Add config.
   mkdir -p docroot/modules/custom
   cp .ddev/misc/phpunit.xml docroot/modules/custom
-  run ddev project-test-phpunit
-  assert_output --partial "Unable to find PHPUnit executable"
-  assert_failure
 
   # Can perform test run, for a group that doesn't exist.
   ddev dkan-init --force

--- a/tests/project-test-phpunit.bats
+++ b/tests/project-test-phpunit.bats
@@ -6,15 +6,21 @@ setup() {
 
   export SUT_DIR=$(pwd)
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-dkan-ddev-addon
+  export PROJNAME=test-dkan-phpunit
   export TESTDIR=~/tmp/$PROJNAME
-  mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
   ddev delete -Oy ${PROJNAME} || true
+  rm -rf $TESTDIR
+  mkdir -p $TESTDIR
   cd "${TESTDIR}"
+  pwd
+
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
+  ddev dkan-init --force
+  mv .ddev/misc/docker-compose.cypress.yaml .ddev/docker-compose.cypress.yml
   ddev restart
+  ddev dkan-site-install
 }
 
 teardown() {


### PR DESCRIPTION
- Removes `webimage_extra_packages` from `config.dkan.yaml`. This was unused anyway and was leading to build errors.
- Changes tests' project names to be unique, so their directories are not re-used.
- Changes `dkan-init.bats` to install from DKAN's recommended project 10.0.0, since 10.1.0 is now our default. The point of the test was to build from a non-standard version.