### PR TITLE
Ensure DDev does not use develop mode for XDebug

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -72,6 +72,7 @@ project_files:
   - misc/settings.dkan.php
   - misc/settings.dkan-snippet.php.txt
   - misc/testUsers.json
+  - php/dkan-php.ini
   - web-build/Dockerfile
 
 # List of files and directories that are copied into the global .ddev directory

--- a/php/dkan-php.ini
+++ b/php/dkan-php.ini
@@ -1,0 +1,2 @@
+[xdebug]
+xdebug.mode = debug


### PR DESCRIPTION
Some tests have been failing because DDev sets XDebug mode to debug,develop.
Add configuration to use only debug.