### PR TITLE
Fix failing HEAD tests

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -73,7 +73,6 @@ project_files:
   - misc/settings.dkan-snippet.php.txt
   - misc/testUsers.json
   - php/dkan-php.ini
-  - web-build/Dockerfile
 
 # List of files and directories that are copied into the global .ddev directory
 # DDEV environment variables can be interpolated into these filenames

--- a/tests/cypress-local.bats
+++ b/tests/cypress-local.bats
@@ -13,6 +13,7 @@ setup() {
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
+  ddev stop
   ddev start -y >/dev/null
   ddev dkan-init --force
   ddev dkan-site-install

--- a/tests/cypress-local.bats
+++ b/tests/cypress-local.bats
@@ -5,16 +5,15 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-ddev-dkan
+  export PROJNAME=test-dkan-ddev-addon
   export TESTDIR=~/tmp/$PROJNAME
   mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
+  ddev delete -Oy ${PROJNAME} || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
-  ddev stop
-  ddev start -y >/dev/null
+  ddev restart
   ddev dkan-init --force
   ddev dkan-site-install
 }
@@ -23,7 +22,7 @@ teardown() {
   set -eu -o pipefail
   echo "teardown..."
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
+  ddev delete -Oy ${PROJNAME}
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 

--- a/tests/cypress-local.bats
+++ b/tests/cypress-local.bats
@@ -13,7 +13,7 @@ setup() {
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
-  ddev restart
+  ddev start
   ddev dkan-init --force
   ddev dkan-site-install
 }

--- a/tests/cypress-local.bats
+++ b/tests/cypress-local.bats
@@ -5,15 +5,15 @@ setup() {
   load 'test_helper/bats-assert/load'
 
   export DIR="$( cd "$( dirname "$BATS_TEST_FILENAME" )" >/dev/null 2>&1 && pwd )/.."
-  export PROJNAME=test-dkan-ddev-addon
+  export PROJNAME=test-ddev-dkan
   export TESTDIR=~/tmp/$PROJNAME
   mkdir -p $TESTDIR
   export DDEV_NON_INTERACTIVE=true
-  ddev delete -Oy ${PROJNAME} || true
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1 || true
   cd "${TESTDIR}"
   ddev config --project-name=${PROJNAME}
   ddev get ${DIR}
-  ddev start
+  ddev start -y >/dev/null
   ddev dkan-init --force
   ddev dkan-site-install
 }
@@ -22,7 +22,7 @@ teardown() {
   set -eu -o pipefail
   echo "teardown..."
   cd ${TESTDIR} || ( printf "unable to cd to ${TESTDIR}\n" && exit 1 )
-  ddev delete -Oy ${PROJNAME}
+  ddev delete -Oy ${PROJNAME} >/dev/null 2>&1
   [ "${TESTDIR}" != "" ] && rm -rf ${TESTDIR}
 }
 

--- a/web-build/Dockerfile
+++ b/web-build/Dockerfile
@@ -1,8 +1,0 @@
-#ddev-generated
-# Cypress.io requirements
-# https://docs.cypress.io/guides/continuous-integration/introduction#Dependencies
-
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
-
-RUN pip3 install yq


### PR DESCRIPTION
ddev HEAD seems to have changed its PHP images to not include python, or more to the point pip. This means we can't just use it to install `yq`.
The obvious question is: Why do we need `yq`? And the answer is: We did, and now we don't. I looked through the codebase here to find where we use `yq`, and couldn't find any usages. I believe we had it to support adding test users in a yaml format.
Therefore, we remove the extra Dockerfile for the PHP container.