### PR TITLE
Add config-set for frontend 404/403 redirect

### DIFF
--- a/commands/web/dkan-frontend-install
+++ b/commands/web/dkan-frontend-install
@@ -46,6 +46,9 @@ npm --loglevel=error install
 
 drush pm-enable dkan_js_frontend -y
 drush config-set system.site page.front '/home' -y
+drush config-set system.site page.403 '/home' -y
+drush config-set system.site page.404 '/home' -y
+
 drush cr
 
 echo " ** Frontend install complete."

--- a/commands/web/dkan-site-install
+++ b/commands/web/dkan-site-install
@@ -16,7 +16,7 @@ drush role:create "administrator" "Administrator" -y
 drush config-set user.role.administrator is_admin true -y
 drush user:role:add "administrator" admin
 
-# Enable Claro and Olivero themes.
+# Enable Claro and Stark themes.
 drush theme:enable claro stark
 drush config-set system.theme admin claro -y
 drush config-set system.theme default stark -y


### PR DESCRIPTION
Add config for 404 and 403 redirects to site-frontend-install to make sure the React app gets the `/home` route when there is a page not found.

Addresses issues in https://github.com/GetDKAN/dkan/issues/4121