### PR TITLE
Initialize with Drupal 10.3 by default

### DIFF
--- a/commands/host/dkan-init
+++ b/commands/host/dkan-init
@@ -16,7 +16,7 @@ export DKAN_DIRECTORY=dkan
 # Defaults.
 INIT_MODULEDEV=false
 INIT_FORCE=false
-INIT_PROJECT_VERSION="10.2.x-dev"
+INIT_PROJECT_VERSION="10.3.x-dev"
 
 # Glean flag arguments.
 while :; do

--- a/tests/dkan-init.bats
+++ b/tests/dkan-init.bats
@@ -40,7 +40,7 @@ teardown() {
   run ddev dkan-init --force
   refute_output --partial "Setting up for local DKAN module development"
   assert_output --partial "Site codebase initialized"
-  assert_output --partial "Using project version: 10.2.x-dev"
+  assert_output --partial "Using project version:"
 
   # Make sure we added our directories.
   assert [ -d "docroot/sites/default/files/uploaded_resources" ]


### PR DESCRIPTION
Everyone's on Drupal 10.3 by now, should be defaulting to this.

Some day, would be nice to have it default to whatever the default branch of recommended-project is (maybe?)