### PR TITLE
Support MySQL 8+ with infile options

### DIFF
--- a/install.yaml
+++ b/install.yaml
@@ -72,6 +72,7 @@ project_files:
   - misc/settings.dkan-snippet.php.txt
   - misc/testUsers.json
   - php/dkan-php.ini
+  - mysql/datastore.cnf
 
 # List of files and directories that are copied into the global .ddev directory
 # DDEV environment variables can be interpolated into these filenames

--- a/mysql/datastore.cnf
+++ b/mysql/datastore.cnf
@@ -1,0 +1,7 @@
+#ddev-generated
+
+[mysqld]
+local_infile=ON
+
+[client]
+loose-local-infile=ON


### PR DESCRIPTION
The bitnami mysql images (used for 8.0+ in ddev) do not have infile enabled by default. We need it for the datastore. This isn't necessary for ddev's mysql 5.7 image but doesn't hurt.