### PR TITLE
Cypress upgrade

### DIFF
--- a/commands/host/dkan-module-test-cypress
+++ b/commands/host/dkan-module-test-cypress
@@ -5,8 +5,8 @@
 ## Usage: dkan-module-test-cypress <arguments>
 
 # This command assumes you have cypress installed globally:
-# (As of this writing, DKAN module needs Cypress 8.7.)
-#   npm install --location=global cypress@8.7
+# (As of this writing, DKAN module needs Cypress 14.1.0.)
+#   npm install --location=global cypress@14.1.0
 #   npx cypress verify
 #   npx cypress info
 
@@ -16,7 +16,7 @@
 set -u -o pipefail
 
 export DKAN_MODULE_PATH=docroot/modules/contrib/dkan
-export DKAN_MODULE_CYPRESS_VERSION=8.7
+export DKAN_MODULE_CYPRESS_VERSION=14.1.0
 
 echo "Starting DKAN module Cypress tests."
 

--- a/misc/docker-compose.cypress.yaml
+++ b/misc/docker-compose.cypress.yaml
@@ -4,7 +4,7 @@ version: '3.6'
 services:
   cypress:
     container_name: ddev-${DDEV_SITENAME}-cypress
-    image: cypress/included:14.1
+    image: cypress/included:14.1.0
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: ddev

--- a/misc/docker-compose.cypress.yaml
+++ b/misc/docker-compose.cypress.yaml
@@ -4,7 +4,7 @@ version: '3.6'
 services:
   cypress:
     container_name: ddev-${DDEV_SITENAME}-cypress
-    image: cypress/included:8.7.0
+    image: cypress/included:14.1
     labels:
       com.ddev.site-name: ${DDEV_SITENAME}
       com.ddev.platform: ddev


### PR DESCRIPTION
This PR upgrades Cypress to install [14.1.0](https://docs.cypress.io/app/references/changelog#14-1-0). This updates allows us to upgrade out cypress tests from 8.7.0 to 14.1.0. What we notice from this upgrade is reliable test runs locally and in our piplelines.